### PR TITLE
Add #! /bin/bash to shell script

### DIFF
--- a/cd.sh
+++ b/cd.sh
@@ -1,3 +1,4 @@
+#! /bin/bash
 # 20171030 CD SCRIPT to replace ONAP on a running VM
 # see INT-120
 #

--- a/git_recurse.sh
+++ b/git_recurse.sh
@@ -1,3 +1,4 @@
+#! /bin/bash
 # F. Michael O'Brien
 # 20170523
 # WIP under construction for

--- a/health.sh
+++ b/health.sh
@@ -1,3 +1,4 @@
+#! /bin/bash
 ssh root@aai1 -o StrictHostKeyChecking=no 'docker ps'
 ssh root@aai2 -o StrictHostKeyChecking=no 'docker ps'
 ssh root@appc -o StrictHostKeyChecking=no 'docker ps'

--- a/prepull_docker.sh
+++ b/prepull_docker.sh
@@ -1,3 +1,4 @@
+#! /bin/bash
 NEXUS3=nexus3.onap.org:10001
 docker login -u docker -p docker nexus3.onap.org:10001
 echo "running docker image pulls in parallel"


### PR DESCRIPTION
Although *.sh files has executable permission,
they can't be executed directly.
Add #! /bin/bash so that they can be executed directly.