### PR TITLE
Change gerrit.openecomp.org to gerrit.onap.org

### DIFF
--- a/git_recurse.sh
+++ b/git_recurse.sh
@@ -104,7 +104,7 @@ pull() {
 clone() {
 	shift;
 	echo "clone for $@"
-	GIT_COMMAND="git clone ssh://$@@gerrit.openecomp.org:29418"
+	GIT_COMMAND="git clone ssh://$@@gerrit.onap.org:29418"
     actionClone
 }
 


### PR DESCRIPTION
In order to have coherent gerrit remotes setup we should probably use `*.onap.org` domain for both *https* and *ssh* protocols.